### PR TITLE
Updated Tags endpoint Recent method.

### DIFF
--- a/src/InstaSharp/Endpoints/Tags.cs
+++ b/src/InstaSharp/Endpoints/Tags.cs
@@ -34,13 +34,20 @@ namespace InstaSharp.Endpoints
         /// <c>Requires Authentication: False</c>
         /// </para>
         /// <param name="tagName">Return information about this tag.</param>
-        /// <param name="min_id">Return media before this min_id. If you don't want to use this parameter, use null.</param>
-        /// <param name="max_id">Return media after this max_id. If you don't want to use this parameter, use null.</param>
-        public Task<MediasResponse> Recent(string tagName, string min_id = "", string max_id = "") {
+        /// <param name="min_tag_id">Return media before this min_tag_id. If you don't want to use this parameter, use null.</param>
+        /// <param name="max_tag_id">Return media after this max_tag_id. If you don't want to use this parameter, use null.</param>
+        /// <param name="count">Count of tagged media to return. Will still be governed by Instagram's enforced limit.</param>
+        public Task<MediasResponse> Recent(string tagName, string min_tag_id = "", string max_tag_id = "", int? count = null) {
             var request = base.Request("{tag}/media/recent");
             request.AddUrlSegment("tag", tagName);
-            request.AddParameter("min_id", min_id);
-            request.AddParameter("max_id", max_id);
+            
+            if (count.HasValue)
+            {
+                request.AddParameter("count", count.Value);
+            }
+            
+            request.AddParameter("min_tag_id", min_tag_id);
+            request.AddParameter("max_tag_id", max_tag_id);
 
             return base.Client.ExecuteAsync<MediasResponse>(request);
         }


### PR DESCRIPTION
Updated the /{tag}/media/recent method to recent spec on the official Instagram API endpoint page:
- Fixing parameters names
- Adding count parameter
