### PR TITLE
Additional check added to Tags.RecentMultiplePages

### DIFF
--- a/src/InstaSharp/Endpoints/Tags.cs
+++ b/src/InstaSharp/Endpoints/Tags.cs
@@ -102,7 +102,14 @@ namespace InstaSharp.Endpoints
                 return response;
             }
 
+            
             var results = await Recent(tagName, minTagId, maxTagId, 100);
+            if (results.Data == null)
+            {
+                response.Meta = results.Meta;
+                return response;
+            }
+
             response.PageCount = 1;
             var idFound = CropDataIfIdFound(results.Data, stopatMediaId);
             response.Data.AddRange(results.Data);


### PR DESCRIPTION
In case of no data after first request (for examle tag "like" which not exists, we got null Data and "This tag cannot be viewed" in error message) we will get an error.
Additional check added.
