### PR TITLE
Create separate model for ListAllSubscriptionsResponse

### DIFF
--- a/src/InstaSharp.Tests/Users.cs
+++ b/src/InstaSharp.Tests/Users.cs
@@ -28,8 +28,8 @@ namespace InstaSharp.Tests
         [TestMethod, TestCategory("Users.Get")]
         public async Task Get_Id()
         {
-            var result = await users.Get("3808579");
-            Assert.IsTrue(result.Data.Username == "nasagoddard", "Parameters: userId");
+            var result = await users.Get("2147645938");
+            Assert.IsTrue(result.Data.Username == "anotherprecioussoul", "Parameters: userId");
         }
 
         [TestMethod, TestCategory("Users.Get")]

--- a/src/InstaSharp/Endpoints/PageReader.cs
+++ b/src/InstaSharp/Endpoints/PageReader.cs
@@ -9,7 +9,7 @@ namespace InstaSharp.Endpoints
         where T1 : IPagination<TResult>
         where TResult : class
     {
-        public async Task<List<TResult>> ReadPages(int userId, Func<int, string, Task<T1>> method, int pageLimit = 0)
+        public async Task<List<TResult>> ReadPages(long userId, Func<long, string, Task<T1>> method, int pageLimit = 0)
         {
             var result = new List<TResult>();
             var pageCount = 0;

--- a/src/InstaSharp/Endpoints/Relationships.cs
+++ b/src/InstaSharp/Endpoints/Relationships.cs
@@ -83,7 +83,7 @@ namespace InstaSharp.Endpoints
         /// </summary>
         /// <param name="userId">The list of users that this user id is following.</param>
         /// <returns>UsersResponse</returns>
-        public Task<UsersResponse> Follows(int userId)
+        public Task<UsersResponse> Follows(long userId)
         {
             return Follows(userId, null);
         }
@@ -96,7 +96,7 @@ namespace InstaSharp.Endpoints
         /// <param name="userId">The list of users that this user id is following.</param>
         /// <param name="cursor">The next cursor id</param>
         /// <returns>UsersResponse</returns>
-        public Task<UsersResponse> Follows(int userId, string cursor)
+        public Task<UsersResponse> Follows(long userId, string cursor)
         {
             var request = Request("{id}/follows");
             request.AddUrlSegment("id", userId.ToString());
@@ -136,7 +136,7 @@ namespace InstaSharp.Endpoints
         /// </summary>
         /// <param name="userId">The list of users that this user id is following.</param>
         /// <returns>UsersResponse</returns>
-        public async Task<List<User>> FollowsAll(int userId)
+        public async Task<List<User>> FollowsAll(long userId)
         {
             AssertIsAuthenticated();
             return await new PageReader<User, UsersResponse>().ReadPages(userId, Follows);
@@ -150,7 +150,7 @@ namespace InstaSharp.Endpoints
         /// </summary>
         /// <param name="userId">The id of the user to get the followers of.</param>
         /// <returns>Users response</returns>
-        public Task<UsersResponse> FollowedBy(int userId)
+        public Task<UsersResponse> FollowedBy(long userId)
         {
             return FollowedBy(userId, null);
         }
@@ -163,7 +163,7 @@ namespace InstaSharp.Endpoints
         /// <param name="userId">The id of the user to get the followers of.</param>
         /// <param name="cursor">The next cursor id</param>
         /// <returns>Users response</returns>
-        public Task<UsersResponse> FollowedBy(int userId, string cursor)
+        public Task<UsersResponse> FollowedBy(long userId, string cursor)
         {
             var request = Request("{id}/followed-by");
             request.AddUrlSegment("id", userId.ToString());
@@ -195,7 +195,7 @@ namespace InstaSharp.Endpoints
         /// </summary>
         /// <param name="userId">The user identifier.</param>
         /// <returns>RelationshipResponse</returns>
-        public Task<RelationshipResponse> Relationship(int userId)
+        public Task<RelationshipResponse> Relationship(long userId)
         {
             var request = Request("{id}/relationship");
             request.AddUrlSegment("id", userId.ToString());
@@ -212,7 +212,7 @@ namespace InstaSharp.Endpoints
         /// <param name="userId">The user id about which to get relationship information.</param>
         /// <param name="action">One of Action enum.</param>
         /// <returns>RelationshipResponse</returns>
-        public Task<RelationshipResponse> Relationship(int userId, Action action)
+        public Task<RelationshipResponse> Relationship(long userId, Action action)
         {
             var request = Request("{id}/relationship", HttpMethod.Post);
             request.AddUrlSegment("id", userId.ToString());

--- a/src/InstaSharp/Endpoints/Subscription.cs
+++ b/src/InstaSharp/Endpoints/Subscription.cs
@@ -215,10 +215,10 @@ namespace InstaSharp.Endpoints
         /// Lists all subscriptions
         /// </summary>
         /// <returns>Subscription Response</returns>
-        public Task<SubscriptionResponse> ListAllSubscriptions()
+        public Task<ListAllSubscriptionsResponse> ListAllSubscriptions()
         {
             var request = Request(null);
-            return Client.ExecuteAsync<SubscriptionResponse>(request);
+            return Client.ExecuteAsync<ListAllSubscriptionsResponse>(request);
         }
     }
 }

--- a/src/InstaSharp/Extensions/HttpClientExtensions.cs
+++ b/src/InstaSharp/Extensions/HttpClientExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Net;
 using InstaSharp.Models.Responses;
 using Newtonsoft.Json;
 using System.Net.Http;
@@ -19,6 +20,14 @@ namespace InstaSharp.Extensions
 
             try
             {
+                if (!response.IsSuccessStatusCode && response.StatusCode == HttpStatusCode.ServiceUnavailable)
+                {
+                    // This is something that happens from now and then when calling the Instagram API
+                    // It probably has to do with some kind of overload on Instagrams side
+                    // Throw an exception with InstaSharpExceptionType.InstagramApiUnavailable and let the caller handle it
+                    throw new InstaSharpException(string.Format("Instagram API is unavailable. Failed to execute request: {0}. Response: {1}", JsonConvert.SerializeObject(request), JsonConvert.SerializeObject(response)), InstaSharpExceptionType.InstagramApiUnavailable);
+                }
+
                 var result = JsonConvert.DeserializeObject<T>(resultData);
 
                 var endpointResponse = result as Response;

--- a/src/InstaSharp/Extensions/HttpClientExtensions.cs
+++ b/src/InstaSharp/Extensions/HttpClientExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using InstaSharp.Models.Responses;
 using Newtonsoft.Json;
 using System.Net.Http;
@@ -49,7 +48,7 @@ namespace InstaSharp.Extensions
             }
             catch (JsonReaderException exception)
             {
-                throw new InstaSharpException(string.Format("Failed to parse {0}", resultData), exception);
+                throw new InstaSharpException(string.Format("Response: {0}. Failed to parse {1}", JsonConvert.SerializeObject(response), resultData), exception);
             }
         }
     }

--- a/src/InstaSharp/InstaSharp.csproj
+++ b/src/InstaSharp/InstaSharp.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Models\RealtimeUpdateItem.cs" />
     <Compile Include="Models\Resolution.cs" />
     <Compile Include="Models\Responses\NamespaceDoc.cs" />
+    <Compile Include="Models\Responses\ListAllSubscriptionsResponse.cs" />
     <Compile Include="Models\Responses\TagsMultiplePagesResponse.cs" />
     <Compile Include="Models\ShortCodeResponse.cs" />
     <Compile Include="Models\UserInPhoto.cs" />

--- a/src/InstaSharp/InstaSharp.csproj
+++ b/src/InstaSharp/InstaSharp.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Endpoints\PageReader.cs" />
     <Compile Include="Models\Attribution.cs" />
     <Compile Include="Models\IncomingStatus.cs" />
+    <Compile Include="Models\InstaSharpException.cs" />
     <Compile Include="Models\MediaSize.cs" />
     <Compile Include="Endpoints\NamespaceDoc.cs" />
     <Compile Include="Endpoints\Relationships.cs" />

--- a/src/InstaSharp/Models/InstaSharpException.cs
+++ b/src/InstaSharp/Models/InstaSharpException.cs
@@ -4,8 +4,22 @@ namespace InstaSharp.Models
 {
     public class InstaSharpException : Exception
     {
-        public InstaSharpException(string message, Exception innerException) : base(message, innerException)
+        public InstaSharpExceptionType InstaSharpExceptionType { get; set; }
+
+        public InstaSharpException(string message, InstaSharpExceptionType instaSharpExceptionType = InstaSharpExceptionType.Unknown) : base(message)
         {
+            InstaSharpExceptionType = instaSharpExceptionType;
         }
+
+        public InstaSharpException(string message, Exception innerException, InstaSharpExceptionType instaSharpExceptionType = InstaSharpExceptionType.Unknown) : base(message, innerException)
+        {
+            InstaSharpExceptionType = instaSharpExceptionType;
+        }
+    }
+
+    public enum InstaSharpExceptionType
+    {
+        Unknown,
+        InstagramApiUnavailable
     }
 }

--- a/src/InstaSharp/Models/InstaSharpException.cs
+++ b/src/InstaSharp/Models/InstaSharpException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace InstaSharp.Models
+{
+    public class InstaSharpException : Exception
+    {
+        public InstaSharpException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/InstaSharp/Models/Location.cs
+++ b/src/InstaSharp/Models/Location.cs
@@ -10,7 +10,7 @@ namespace InstaSharp.Models {
         /// <value>
         /// The identifier.
         /// </value>
-        public int Id { get; set; }
+        public long Id { get; set; }
         /// <summary>
         /// Gets or sets the latitude.
         /// </summary>

--- a/src/InstaSharp/Models/RealtimeUpdateItem.cs
+++ b/src/InstaSharp/Models/RealtimeUpdateItem.cs
@@ -14,7 +14,7 @@ namespace InstaSharp.Models
         /// The sub scription identifier.
         /// </value>
         [JsonProperty("SubScription_ID")]
-        public int SubScriptionId { get; set; }
+        public long SubScriptionId { get; set; }
 
         /// <summary>
         /// Gets or sets the object.

--- a/src/InstaSharp/Models/Responses/ListAllSubscriptionsResponse.cs
+++ b/src/InstaSharp/Models/Responses/ListAllSubscriptionsResponse.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace InstaSharp.Models.Responses
+{
+    /// <summary>
+    /// List All Subscriptions Response
+    /// </summary>
+    public class ListAllSubscriptionsResponse : Response
+    {
+        /// <summary>
+        /// Gets or sets the data.
+        /// </summary>
+        /// <value>
+        /// The data.
+        /// </value>
+        public IEnumerable<Subscription> Data { get; set; }
+    }
+}

--- a/src/InstaSharp/Models/UserInfo.cs
+++ b/src/InstaSharp/Models/UserInfo.cs
@@ -11,7 +11,7 @@ namespace InstaSharp.Models {
         /// <value>
         /// The identifier.
         /// </value>
-        public int Id { get; set; }
+        public long Id { get; set; }
         /// <summary>
         /// Gets or sets the username.
         /// </summary>


### PR DESCRIPTION
Hi!
I found that when listing Real Time API subscriptions, Instagram returns a list of ```Subscription```s. This commit fixes that. :)

Maybe there is a better name for the model than ```ListAllSubscriptionsResponse```?