### PR TITLE
Added Content-Type: application/x-www-form-urlencoded header

### DIFF
--- a/src/InstaSharp/OAuth.cs
+++ b/src/InstaSharp/OAuth.cs
@@ -120,7 +120,7 @@ namespace InstaSharp
                 config.RedirectUri.UrlEncode(), 
                 code.UrlEncode());
 
-            request.Content = new StringContent(myParameters);
+            request.Content = new StringContent(myParameters, Encoding.UTF8, "application/x-www-form-urlencoded");
 
             return client.ExecuteAsync<OAuthResponse>(request);
 


### PR DESCRIPTION
Added a Content-Type: application/x-www-form-urlencoded header. Otherwise, the parameters send when making a request for the access tokens are not accepted by Instagram since recently and a 400 bad request - You must provide a client_id is returned.